### PR TITLE
chore: add TypeDoc support and align tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ jspm_packages/
 dist/
 build/
 out/
+docs/
 *.tsbuildinfo
 
 # Environment configuration files

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 *.md
 dist
 build
+docs

--- a/devbox.json
+++ b/devbox.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jetpack-io/devbox/0.10.3/.schema/devbox.schema.json",
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.10.7/.schema/devbox.schema.json",
   "packages": ["nodejs@22"],
   "env": {
     "NPM_CONFIG_CACHE": "$DEVBOX_PROJECT_ROOT/.npm"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import mridang from '@mridang/eslint-defaults';
 
 export default [
   {
-    ignores: ['README.md', 'README.md/**'],
+    ignores: ['README.md', 'README.md/**', 'docs/**'],
   },
   ...mridang.configs.recommended,
 ];

--- a/knip.config.js
+++ b/knip.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  ignore: ['commitlint.config.js'],
+  ignore: ['commitlint.config.js', 'docs/**'],
   ignoreDependencies: [
     '@commitlint/config-conventional',
     '@semantic-release/.*?',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@auth/core": "^0.40.0",
         "@commitlint/config-conventional": "^20.5.0",
         "@jest/globals": "^30.0.5",
-        "@mridang/eslint-defaults": "^1.6.1",
+        "@mridang/eslint-defaults": "^1.6.3",
         "@nestjs/common": "11.1.5",
         "@nestjs/core": "11.1.18",
         "@nestjs/platform-express": "11.1.15",
@@ -44,6 +44,7 @@
         "supertest": "^7.1.4",
         "testcontainers": "^11.5.0",
         "ts-jest": "29.4.0",
+        "typedoc": "^0.28.7",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -1160,6 +1161,20 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -2523,9 +2538,9 @@
       }
     },
     "node_modules/@mridang/eslint-defaults": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@mridang/eslint-defaults/-/eslint-defaults-1.6.1.tgz",
-      "integrity": "sha512-jM/AT4+Dmx1vdpuGInz5LE1A7OcODo+j0xQU9ILt9EaGgdotFRue51WPCr/dWhs5ZDms92ly8mo7GQRfqL2Q/w==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@mridang/eslint-defaults/-/eslint-defaults-1.6.3.tgz",
+      "integrity": "sha512-pdPkTBt7EjVI0lw5pTdQd1wt49tSAuN1ZNHXyOrFm0BpCvBFAezqJo+WGWFAimTWWLFBwZYINSZIi1wF/ZjnGQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3808,6 +3823,55 @@
         "semantic-release": ">=20.1.0"
       }
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@simple-libs/stream-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
@@ -4054,6 +4118,16 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/http-errors": {
@@ -7566,6 +7640,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-ci": {
@@ -13793,6 +13880,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/load-esm": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.2.tgz",
@@ -13980,6 +14077,13 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/make-asynchronous": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.0.1.tgz",
@@ -14042,6 +14146,24 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-table": {
@@ -14379,6 +14501,13 @@
       "integrity": "sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -18697,6 +18826,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -21670,6 +21809,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/typedoc": {
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -21683,6 +21885,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "format:check": "prettier --check .",
     "lint": "npx eslint .",
     "lint:fix": "npx eslint . --fix",
-    "depcheck": "npx knip"
+    "depcheck": "npx knip",
+    "docs": "typedoc"
   },
   "files": [
     "dist"
@@ -65,7 +66,7 @@
     "@auth/core": "^0.40.0",
     "@commitlint/config-conventional": "^20.5.0",
     "@jest/globals": "^30.0.5",
-    "@mridang/eslint-defaults": "^1.6.1",
+    "@mridang/eslint-defaults": "^1.6.3",
     "@nestjs/common": "11.1.5",
     "@nestjs/core": "11.1.18",
     "@nestjs/platform-express": "11.1.15",
@@ -93,6 +94,7 @@
     "supertest": "^7.1.4",
     "testcontainers": "^11.5.0",
     "ts-jest": "29.4.0",
+    "typedoc": "^0.28.7",
     "typescript": "^5.9.3"
   },
   "repository": {

--- a/src/auth.decorators.ts
+++ b/src/auth.decorators.ts
@@ -75,9 +75,6 @@ export const RequireRoles = (...roles: readonly string[]): MethodDecorator =>
  * Returns `null` if no valid session exists (user is not authenticated).
  * Access the user data via `session.user` and session metadata via other properties.
  *
- * @param data - Optional data parameter (not used in this implementation)
- * @param ctx - The execution context provided by NestJS
- *
  * @example
  * ```ts
  * @Controller('profile')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './adapters/http.adapter.js';
 export * from './auth.guards.js';
 export * from './auth.module.js';
 export * from './auth.decorators.js';

--- a/typedoc.config.cjs
+++ b/typedoc.config.cjs
@@ -1,0 +1,32 @@
+/** @type {import('typedoc').TypeDocOptions} */
+module.exports = {
+  entryPoints: ['src/index.ts', 'src/adapter.ts'],
+  out: 'docs',
+  tsconfig: './tsconfig.json',
+  readme: 'none',
+  excludeInternal: true,
+  excludePrivate: true,
+  externalSymbolLinkMappings: {
+    oauth4webapi: {
+      'TokenEndpointResponse.expires_in':
+        'https://github.com/panva/oauth4webapi',
+      'TokenEndpointResponse.access_token':
+        'https://github.com/panva/oauth4webapi',
+      'TokenEndpointResponse.refresh_token':
+        'https://github.com/panva/oauth4webapi',
+    },
+    '@auth/core': {
+      'AuthConfig.adapter': 'https://authjs.dev/reference/core',
+      'AuthConfig.session': 'https://authjs.dev/reference/core',
+      'AuthConfig.logger': 'https://authjs.dev/reference/core',
+      'AuthConfig.debug': 'https://authjs.dev/reference/core',
+      'AuthConfig.pages': 'https://authjs.dev/reference/core',
+      JWT: 'https://authjs.dev/reference/core/jwt',
+      'OAuthConfig.profile': 'https://authjs.dev/reference/core/providers',
+      'CredentialsConfig.authorize':
+        'https://authjs.dev/reference/core/providers/credentials',
+      TokenSet: 'https://authjs.dev/reference/core/types',
+      'OAuth2Config.checks': 'https://authjs.dev/reference/core/providers',
+    },
+  },
+};

--- a/typedoc.config.mjs
+++ b/typedoc.config.mjs
@@ -1,5 +1,5 @@
 /** @type {import('typedoc').TypeDocOptions} */
-module.exports = {
+export default {
   entryPoints: ['src/index.ts', 'src/adapter.ts'],
   out: 'docs',
   tsconfig: './tsconfig.json',


### PR DESCRIPTION
## Description

Add TypeDoc API documentation generation and align tooling configuration with the other @zitadel/*-auth libraries. This adds `typedoc.config.cjs`, a `docs` script, and updates ignore files to exclude the generated `docs/` directory. Also exports `HttpAdapter` from index.ts, removes unused `@param` JSDoc tags from the `@AuthSession()` decorator, and bumps `@mridang/eslint-defaults` to ^1.6.3.

## Motivation and Context

Aligns this library's tooling with the other @zitadel/*-auth libraries which all have TypeDoc configured for API documentation generation.

## How Has This Been Tested?

Build, lint, format check, depcheck, and docs generation all pass.